### PR TITLE
Fix wrong parameter order with workspaceIsFolder option

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2932,10 +2932,10 @@ function format(options) {
         };
         const dotnetFormatOptions = ["format"];
         if (options.workspace !== undefined && options.workspace != "") {
-            dotnetFormatOptions.push(options.workspace);
             if (options.workspaceIsFolder) {
                 dotnetFormatOptions.push("-f");
             }
+            dotnetFormatOptions.push(options.workspace);
         }
         if (options.dryRun) {
             dotnetFormatOptions.push("--check");

--- a/src/dotnet.ts
+++ b/src/dotnet.ts
@@ -43,11 +43,11 @@ export async function format(options: FormatOptions): Promise<boolean> {
   const dotnetFormatOptions = ["format"];
 
   if (options.workspace !== undefined && options.workspace != "") {
-    dotnetFormatOptions.push(options.workspace);
-
     if (options.workspaceIsFolder) {
       dotnetFormatOptions.push("-f");
     }
+    
+    dotnetFormatOptions.push(options.workspace);
   }
 
   if (options.dryRun) {


### PR DESCRIPTION
The "-f" is being added after the path, producing an output that looks like this (putting "." as workspace):
`dotnet format . -f`
and triggering an error: 
```
Unrecognized command or argument '.'
Required argument missing for option: -f
```

I've just changed the order so the -f is added before the path, if it has to be added. Nothing should change for the other cases.

I don't have a deep knowledge of github actions or of this specific repo, I've modified the two files where I could find the `workspaceIsFolder` adding the "-f", but feel free to improve my solution if there's a better way of doing it.