### PR TITLE
Change logging level parsing to match documentation

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1266,7 +1266,7 @@ function buildOptions() {
     const workspace = core_1.getInput("workspace");
     const workspaceIsFolder = core_1.getInput("workspaceIsFolder") === "true";
     const exclude = core_1.getInput("exclude");
-    const logLevel = core_1.getInput("log-level");
+    const logLevel = core_1.getInput("logLevel");
     const fixWhitespace = core_1.getInput("fix-whitespace") === "true";
     const fixAnalyzersLevel = core_1.getInput("fix-analyzers-level");
     const fixStyleLevel = core_1.getInput("fix-style-level");

--- a/dist/index.js
+++ b/dist/index.js
@@ -2932,10 +2932,10 @@ function format(options) {
         };
         const dotnetFormatOptions = ["format"];
         if (options.workspace !== undefined && options.workspace != "") {
-            dotnetFormatOptions.push(options.workspace);
             if (options.workspaceIsFolder) {
                 dotnetFormatOptions.push("-f");
             }
+            dotnetFormatOptions.push(options.workspace);
         }
         if (options.dryRun) {
             dotnetFormatOptions.push("--check");

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -8,7 +8,7 @@ function buildOptions(): FormatOptions {
   const workspace: string = getInput("workspace");
   const workspaceIsFolder = getInput("workspaceIsFolder") === "true";
   const exclude: string = getInput("exclude");
-  const logLevel: string = getInput("log-level");
+  const logLevel: string = getInput("logLevel");
   const fixWhitespace = getInput("fix-whitespace") === "true";
   const fixAnalyzersLevel: string = getInput("fix-analyzers-level");
   const fixStyleLevel: string = getInput("fix-style-level");

--- a/src/dotnet.ts
+++ b/src/dotnet.ts
@@ -43,11 +43,11 @@ export async function format(options: FormatOptions): Promise<boolean> {
   const dotnetFormatOptions = ["format"];
 
   if (options.workspace !== undefined && options.workspace != "") {
-    dotnetFormatOptions.push(options.workspace);
-
     if (options.workspaceIsFolder) {
       dotnetFormatOptions.push("-f");
     }
+    
+    dotnetFormatOptions.push(options.workspace);
   }
 
   if (options.dryRun) {


### PR DESCRIPTION
The logging level option is being parsed as "log-level", but both the documentation and some sort of validator say it should be "logLevel".
![Screenshot 2022-03-30 at 17 22 18](https://user-images.githubusercontent.com/61145092/160871398-5f9f693f-5083-4530-9217-7df23515cc11.png)

This PR changes both places where the code tries to get "log-level" to instead use "logLevel".
 